### PR TITLE
added remotes to description file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,5 +25,15 @@ Imports:
     pastecs,
     smwrStats,
     matrixStats,
-    geosphere
-RoxygenNote: 6.0.0
+    geosphere,
+    Lmoments,
+    Matrix,
+    RandomFields,
+    goftest,
+    mgcv,
+    nlme,
+    splancs
+Remotes: 
+    github::USGS-R/smwrQW,
+    github::USGS-R/smwrStats
+RoxygenNote: 6.0.1


### PR DESCRIPTION
I added several remotes to the DESCRIPTION file which should prevent dependency errors when downloading the package:

```r
Remotes: 
    github::USGS-R/smwrQW,
    github::USGS-R/smwrStats
```

I also had to add several packages in the "imports" section that were in the NAMESPACE but not the DESCRIPTION and was causing check errors.  